### PR TITLE
Fix the URL for YSWS rules

### DIFF
--- a/src/content/posts/quality-integrity-manager.mdx
+++ b/src/content/posts/quality-integrity-manager.mdx
@@ -46,7 +46,7 @@ The problem was the middle. The edge cases. A project that was decent but maybe 
 
 That works fine when you have a handful of programs and a small team. It stops working when you have dozens of programs, hundreds of reviewers, and thousands of submissions flowing into one shared database.
 
-So we wrote the rules down. They live at [hackclub.com/ysws-rules](https://hackclub.com/ysws-rules). Every ship that lands in the database has to clear them. The point isn’t to be prescriptive about what teenagers can build (build whatever you want, that’s the whole game), it’s to take those judgment calls that used to depend on who you asked and give them one consistent answer.
+So we wrote the rules down. They live at [hackclub.com/ysws-rules](https://https://hack.club/ysws-rules). Every ship that lands in the database has to clear them. The point isn’t to be prescriptive about what teenagers can build (build whatever you want, that’s the whole game), it’s to take those judgment calls that used to depend on who you asked and give them one consistent answer.
 
 For the past few weeks I’ve been going program by program, flagging issues to authors directly and gathering feedback as we iterate.
 


### PR DESCRIPTION
Added the correct link for the YSWS rules, from hackclub.com to hack.club 