### PR TITLE
Add headline images

### DIFF
--- a/src/lib/content.ts
+++ b/src/lib/content.ts
@@ -18,6 +18,10 @@ export type Post = {
     date: Date;
     excerpt: string;
     paragraphs: string[];
+    leadingImage?: {
+        src: string;
+        alt: string;
+    };
     entry: CollectionEntry<"posts">;
 };
 
@@ -76,18 +80,58 @@ function stripMarkdown(input: string): string {
     );
 }
 
-function extractBlocks(body: string): string[] {
+function getBodyBlocks(body: string): string[] {
     return body
         .replace(/^import\s.+$/gm, "")
         .replace(/^export\s.+$/gm, "")
         .split(/\n{2,}/)
+        .map((block) => block.trim())
+        .filter(Boolean);
+}
+
+function getAttributeValue(tag: string, attribute: string): string | undefined {
+    return tag.match(new RegExp(`${attribute}=["']([^"']*)["']`, "i"))?.[1];
+}
+
+function extractImageFromBlock(block: string): { src: string; alt: string } | undefined {
+    const markdownImage = block.match(/^!\[([^\]]*)\]\(([^)\s]+)(?:\s+"[^"]*")?\)$/s);
+    if (markdownImage) {
+        return {
+            alt: markdownImage[1],
+            src: markdownImage[2]
+        };
+    }
+
+    const imgTag = block.match(/<img\b[^>]*>/i);
+    if (!imgTag) {
+        return undefined;
+    }
+
+    const tag = imgTag[0];
+    const src = getAttributeValue(tag, "src");
+    if (!src) {
+        return undefined;
+    }
+
+    return {
+        src,
+        alt: getAttributeValue(tag, "alt") ?? ""
+    };
+}
+
+function extractTextBlocks(body: string): string[] {
+    const blocks = getBodyBlocks(body);
+    const leadingImage = extractImageFromBlock(blocks[0] ?? "");
+
+    return blocks
+        .slice(leadingImage ? 1 : 0)
         .map((block) => stripMarkdown(block))
         .filter(Boolean);
 }
 
 function toExcerpt(entry: { body: string; data: { excerpt?: string } }): string {
     const explicitExcerpt = entry.data.excerpt;
-    const source = explicitExcerpt ?? extractBlocks(entry.body)[0] ?? "";
+    const source = explicitExcerpt ?? extractTextBlocks(entry.body)[0] ?? "";
 
     return stripMarkdown(source);
 }
@@ -105,7 +149,9 @@ export async function getPosts(): Promise<Post[]> {
     return posts
         .sort((a, b) => b.data.date.getTime() - a.data.date.getTime())
         .map((entry) => {
-            const paragraphs = extractBlocks(entry.body);
+            const bodyBlocks = getBodyBlocks(entry.body);
+            const leadingImage = extractImageFromBlock(bodyBlocks[0] ?? "");
+            const paragraphs = extractTextBlocks(entry.body);
             const [category] = entry.slug.split("/", 1);
 
             return {
@@ -117,6 +163,7 @@ export async function getPosts(): Promise<Post[]> {
                 date: entry.data.date,
                 excerpt: toExcerpt(entry),
                 paragraphs,
+                leadingImage,
                 entry
             } satisfies Post;
         });

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -16,6 +16,7 @@ const frontpage = await getFrontpageData();
 
 const headlineSlug = frontpage.headline?.[0];
 const headline = posts.find((post) => post.slug === headlineSlug);
+const headlineExcerpts = headline?.paragraphs.slice(0, headline?.leadingImage ? 1 : 2) ?? [];
 
 const allOpinion = posts.filter((post) => post.category === "opinion");
 const opinionSlugs = frontpage.opinion ?? [];
@@ -48,12 +49,25 @@ const acknowledgements = await getAcknowledgements();
     <div class="front-top">
       {headline && (
         <a href={headline.url} class="front-block headline-block">
-          <h2 class="block-headline">{headline.title}</h2>
-          <hr class="block-rule" />
-          <div class="block-excerpts">
-            {headline.paragraphs.slice(0, 2).map((paragraph) => (
-              <p class="block-excerpt">{paragraph}</p>
-            ))}
+          {headline.leadingImage && (
+            <div class="headline-media">
+              <img
+                src={headline.leadingImage.src}
+                alt={headline.leadingImage.alt}
+                loading="eager"
+                decoding="async"
+              />
+            </div>
+          )}
+
+          <div class="headline-content">
+            <h2 class="block-headline">{headline.title}</h2>
+            <hr class="block-rule" />
+            <div class="block-excerpts">
+              {headlineExcerpts.map((paragraph) => (
+                <p class="block-excerpt">{headline.leadingImage ? paragraph : truncateWords(paragraph, 28)}</p>
+              ))}
+            </div>
           </div>
         </a>
       )}

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -150,6 +150,28 @@ a {
 .headline-block {
   display: flex;
   flex-direction: column;
+
+  .headline-media {
+    margin: -24px -22px 16px;
+    overflow: hidden;
+    border-radius: 12px 12px 0 0;
+    background: #e8e8e2;
+
+    img {
+      display: block;
+      width: 100%;
+      aspect-ratio: 16 / 7;
+      object-fit: cover;
+      object-position: center;
+    }
+  }
+
+  .headline-content {
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+  }
+
   .block-headline {
     font-size: 2rem;
     font-weight: 900;


### PR DESCRIPTION
**Article w/ image before (headline image just shows alt text):**

<img width="1968" height="1378" alt="image" src="https://github.com/user-attachments/assets/df911971-128a-4ee9-bdd5-f1677bdb816b" />

**Article w/ image after:**

<img width="1968" height="1378" alt="image" src="https://github.com/user-attachments/assets/599abd87-8714-4fc6-9ab8-fa02f995d5ff" />

**Text-only article before:**

<img width="1968" height="1378" alt="image" src="https://github.com/user-attachments/assets/d6e4a508-cef3-4b2a-b4c6-fe4e58c3bdad" />

**Text-only articles after:**

<img width="1968" height="1378" alt="image" src="https://github.com/user-attachments/assets/4ed36bac-eb5c-4918-951e-b62be716409e" />


