### PR TITLE
fix: improve paragraph spacing on pages

### DIFF
--- a/src/layouts/PageLayout.astro
+++ b/src/layouts/PageLayout.astro
@@ -16,6 +16,8 @@ const { pageTitle, siteTitle, siteDescription, Content } = Astro.props;
     <header class="post-header">
       <h1 class="post-title">{pageTitle}</h1>
     </header>
-    <Content />
+    <div class="post-content">
+      <Content />
+    </div>
   </article>
 </BaseLayout>


### PR DESCRIPTION
**Before**

<img width="1107" height="691" alt="image" src="https://github.com/user-attachments/assets/04d55602-ed72-4dca-8379-204d09a8b75c" />


**After**

<img width="1109" height="687" alt="image" src="https://github.com/user-attachments/assets/13aca573-3f15-4aa7-b093-3ed778d8d859" />
