### PR TITLE
feat: site footer with SN logo, HC flag, commit link, column nav

### DIFF
--- a/src/components/SiteFooter.astro
+++ b/src/components/SiteFooter.astro
@@ -1,0 +1,164 @@
+---
+import { execSync } from "child_process";
+
+let commitHash: string;
+try {
+  commitHash = execSync("git rev-parse --short HEAD", { encoding: "utf-8" }).trim();
+} catch {
+  commitHash = "dev";
+}
+---
+
+<footer class="site-footer">
+  <div class="wrapper">
+    <div class="footer-inner">
+      <div class="footer-brand">
+        <img src="/Core%20SN%20logo.svg" alt="Slacker News" class="footer-logo-img" />
+        <span class="footer-tagline">
+          Official News of the
+          <img src="https://assets.hackclub.com/flag-standalone.svg" alt="Hack Club" class="footer-hc-inline" />
+          Hack Club Slack
+        </span>
+        <span class="footer-commit">Built from commit <a href="https://github.com/hackclub/slacker-news/commit/{commitHash}"><code>#{commitHash}</code></a></span>
+      </div>
+        <div class="footer-nav">
+          <div class="footer-col">
+            <span class="footer-col-title">Sections</span>
+            <a href="/">Home</a>
+            <a href="/news/">News</a>
+            <a href="/opinion/">Opinion</a>
+            <a href="/essays/">Essays</a>
+            <a href="/changelogs/">Changelogs</a>
+          </div>
+          <div class="footer-col">
+            <span class="footer-col-title">About</span>
+            <a href="/about/">About</a>
+            <a href="/submissions/">Submissions</a>
+            <a href="/acknowledgements/">Acknowledgements</a>
+          </div>
+          <div class="footer-col">
+            <span class="footer-col-title">Tools</span>
+            <a href="/search/">Search</a>
+            <a href="/feed.xml">RSS</a>
+            <a href="https://plausible.io/news.hackclub.com">Stats</a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</footer>
+
+<style>
+  .site-footer {
+    background: #f5f5f0;
+    padding: 32px 20px;
+    border-top: 3px solid #000;
+  }
+
+  .footer-inner {
+    display: flex;
+    align-items: flex-start;
+    justify-content: flex-start;
+    row-gap: 20px;
+    column-gap: 80px;
+  }
+
+  .footer-brand {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    flex-shrink: 0;
+  }
+
+  .footer-logo-img {
+    height: 5em;
+    vertical-align: middle;
+    width: fit-content;
+  }
+
+  .footer-tagline {
+    font-family: Georgia, "Times New Roman", serif;
+    font-size: 0.85rem;
+    font-style: italic;
+    color: #555;
+    letter-spacing: 0.02em;
+    display: flex;
+    align-items: center;
+    gap: 6px;
+  }
+
+  .footer-hc-inline {
+    height: 1.2em;
+    width: auto;
+    filter: grayscale(1);
+    vertical-align: middle;
+  }
+
+  .footer-commit {
+    font-family: Georgia, "Times New Roman", serif;
+    font-size: 0.75rem;
+    color: #555;
+    letter-spacing: 0.04em;
+    width: fit-content;
+  }
+
+  .footer-commit a {
+    color: #555;
+    text-decoration: none;
+  }
+
+  .footer-commit a:hover {
+    text-decoration: underline;
+  }
+
+  .footer-commit code {
+    font-family: "SF Mono", "Fira Code", "Fira Mono", monospace;
+    font-weight: 600;
+  }
+
+  .footer-nav {
+    display: flex;
+    justify-content: space-between;
+    gap: 24px;
+    flex: 1;
+  }
+
+  .footer-col {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 8px;
+    font-family: Georgia, "Times New Roman", serif;
+    font-size: 0.8rem;
+    letter-spacing: 0.04em;
+  }
+
+  .footer-col-title {
+    font-weight: 700;
+    text-transform: uppercase;
+    font-size: 0.7rem;
+    letter-spacing: 0.1em;
+    color: #555;
+    margin-bottom: 4px;
+  }
+
+  .footer-col a {
+    color: #000;
+    text-decoration: none;
+  }
+
+  .footer-col a:hover {
+    text-decoration: underline;
+  }
+
+  @media (max-width: 600px) {
+    .footer-inner {
+      flex-direction: column;
+      align-items: flex-start;
+    }
+
+    .footer-nav {
+      flex-wrap: wrap;
+    }
+  }
+</style>

--- a/src/components/SiteFooter.astro
+++ b/src/components/SiteFooter.astro
@@ -19,7 +19,7 @@ try {
           <img src="https://assets.hackclub.com/flag-standalone.svg" alt="Hack Club" class="footer-hc-inline" />
           Hack Club Slack
         </span>
-        <span class="footer-commit">Built from commit <a href="https://github.com/hackclub/slacker-news/commit/{commitHash}"><code>#{commitHash}</code></a></span>
+        <span class="footer-commit">Built from commit <a href={`https://github.com/hackclub/slacker-news/commit/${commitHash}`}><code>#{commitHash}</code></a></span>
       </div>
         <div class="footer-nav">
           <div class="footer-col">

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -1,5 +1,6 @@
 ---
 import AbacusCounter from "../components/AbacusCounter.astro";
+import SiteFooter from "../components/SiteFooter.astro";
 
 interface Props {
   title?: string;
@@ -244,5 +245,6 @@ const socialImageAlt = openGraphImageAlt ?? `${siteTitle} social preview`;
       })();
     </script>
     <AbacusCounter pathname={Astro.url.pathname} />
+    <SiteFooter />
   </body>
 </html>

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -911,6 +911,15 @@ html.dark-mode {
   .site-title img {
     filter: none;
   }
+
+  .footer-logo-img {
+    filter: none;
+  }
+
+  .footer-commit,
+  .footer-commit a {
+    color: #ccc !important;
+  }
 }
 
 @media (prefers-color-scheme: dark) {
@@ -926,6 +935,15 @@ html.dark-mode {
 
     .site-title img {
       filter: none;
+    }
+
+    .footer-logo-img {
+      filter: none;
+    }
+
+    .footer-commit,
+    .footer-commit a {
+      color: #ccc !important;
     }
 
     mark {


### PR DESCRIPTION
## Summary
- SN logo (5em, width: fit-content)
- HC flag logo (greyscale, inline with tagline)
- "Official News of the Hack Club Slack" tagline
- "Built from commit #SHA" linking to GitHub
- Column nav: Sections, About, Tools
- Left-aligned, row-gap 20px, column-gap 80px
- Dark mode: logo turns white, commit label #ccc