### PR TITLE
feat: stepped JS ticker with newswire label, pause button

### DIFF
--- a/src/components/AcknowledgementsTicker.astro
+++ b/src/components/AcknowledgementsTicker.astro
@@ -1,0 +1,267 @@
+---
+import { getAcknowledgements } from "../lib/content";
+
+const acknowledgements = await getAcknowledgements();
+---
+
+<div class="ack-ticker" aria-label="Acknowledgements ticker">
+  <span class="ack-ticker-credit">With ♥ By</span>
+  <div class="ack-ticker-track">
+    <div class="ack-ticker-scroll" data-ticker>
+      <span class="ack-ticker-set" data-ticker-set>
+        {acknowledgements.map((person, i) => (
+          <>
+            {i > 0 && <span class="ack-ticker-divider" aria-hidden="true">◆</span>}
+            <span class="ack-ticker-entry">
+              <span class="ack-ticker-name" data-slack-id={person.slackId ?? ""}>@{person.name.trim().replace(/^@+/, "")}</span>
+            </span>
+          </>
+        ))}
+      </span>
+    </div>
+  </div>
+  <a href="/acknowledgements/" class="ack-ticker-label">All &rarr;</a>
+</div>
+
+<script is:inline>
+  const ACK_CACHE_KEY = "ack-ticker:names:v1";
+  const SLACK_TEAM_URL = "https://hackclub.slack.com/team/";
+
+  function resolveNames(names) {
+    document.querySelectorAll(".ack-ticker-name[data-slack-id]").forEach((el) => {
+      const id = el.getAttribute("data-slack-id");
+      if (!id) return;
+      const originalName = el.textContent.replace(/^@/, "").trim();
+      const displayName = names.get(id) || originalName;
+      if (!displayName) return;
+      const link = document.createElement("a");
+      link.className = "slack_user";
+      link.href = SLACK_TEAM_URL + encodeURIComponent(id);
+      link.target = "_blank";
+      link.rel = "noreferrer noopener";
+      link.textContent = "@" + displayName;
+      el.replaceWith(link);
+    });
+  }
+
+  function extractName(payload, depth) {
+    if (depth > 4 || !payload) return undefined;
+    if (Array.isArray(payload)) {
+      for (const v of payload) {
+        const n = extractName(v, depth + 1);
+        if (n) return n;
+      }
+      return undefined;
+    }
+    if (typeof payload !== "object") return undefined;
+    const candidates = [
+      payload.displayName, payload.display_name,
+      payload.name, payload.username, payload.userName,
+      payload.user_name, payload.handle,
+    ];
+    const name = candidates.find((v) => typeof v === "string" && v.trim());
+    if (name) return name.replace(/^@+/, "");
+    for (const key of ["data", "user", "profile"]) {
+      const n = extractName(payload[key], depth + 1);
+      if (n) return n;
+    }
+    return undefined;
+  }
+
+  async function fetchName(id) {
+    if (!/^[UW][A-Z0-9]+$/i.test(id)) return undefined;
+    try {
+      const res = await fetch("https://cachet.hackclub.com/get/users/" + encodeURIComponent(id), {
+        headers: { Accept: "application/json" },
+      });
+      if (res.ok) {
+        const name = extractName(await res.json(), 0);
+        if (name) return name;
+      }
+    } catch {}
+    try {
+      for (const route of ["user", "users"]) {
+        const res = await fetch("https://flaron.halceon.dev/" + route + "/" + encodeURIComponent(id), {
+          headers: { Accept: "application/json" },
+        });
+        if (res.ok) {
+          const name = extractName(await res.json(), 0);
+          if (name) return name;
+        }
+      }
+    } catch {}
+    return undefined;
+  }
+
+  async function fetchNames(ids) {
+    const results = await Promise.all(ids.map(async (id) => [id, await fetchName(id)]));
+    return new Map(results);
+  }
+
+  async function initializeAckTicker() {
+    try {
+      const cached = JSON.parse(sessionStorage.getItem(ACK_CACHE_KEY) || "null");
+      if (cached) resolveNames(new Map(Object.entries(cached)));
+    } catch {}
+
+    const els = document.querySelectorAll(".ack-ticker-name[data-slack-id]");
+    const ids = [...new Set([...els].map((el) => el.getAttribute("data-slack-id")).filter(Boolean))];
+    if (ids.length === 0) return;
+
+    const names = await fetchNames(ids);
+    resolveNames(names);
+
+    try {
+      sessionStorage.setItem(ACK_CACHE_KEY, JSON.stringify(Object.fromEntries(names)));
+    } catch {}
+  }
+
+  function initializeTickerScroll() {
+    document
+      .querySelectorAll(".ack-ticker-scroll:not([data-ticker-initialized])")
+      .forEach((scroll) => {
+        if (!(scroll instanceof HTMLElement)) return;
+        scroll.setAttribute("data-ticker-initialized", "true");
+        const set = scroll.querySelector(".ack-ticker-set");
+        if (!(set instanceof HTMLElement)) return;
+
+        const items = Array.from(set.querySelectorAll(".ack-ticker-entry"));
+        if (items.length === 0) return;
+
+        const dupe = set.cloneNode(true);
+        if (!(dupe instanceof HTMLElement)) return;
+        dupe.setAttribute("aria-hidden", "true");
+        scroll.appendChild(dupe);
+
+        let index = 0;
+        const step = () => {
+          index++;
+          const next = items[index];
+          if (next instanceof HTMLElement) {
+            scroll.style.transform = `translateX(-${next.offsetLeft}px)`;
+            return;
+          }
+
+          scroll.addEventListener(
+            "transitionend",
+            () => {
+              scroll.style.transition = "none";
+              scroll.style.transform = "translateX(0)";
+              index = 0;
+              requestAnimationFrame(() => {
+                scroll.style.transition = "";
+              });
+            },
+            { once: true },
+          );
+          scroll.style.transform = `translateX(-${set.offsetWidth}px)`;
+        };
+
+        window.setInterval(step, 4000);
+      });
+  }
+
+  function init() {
+    initializeTickerScroll();
+    initializeAckTicker();
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", init);
+  } else {
+    init();
+  }
+  document.addEventListener("astro:page-load", init);
+  new MutationObserver(initializeTickerScroll).observe(document.body, { childList: true, subtree: true });
+</script>
+
+<style>
+  .ack-ticker {
+    background: #f5f5f0;
+    color: #000;
+    display: flex;
+    align-items: stretch;
+    overflow: hidden;
+    font-family: Georgia, "Times New Roman", serif;
+    font-size: 0.8rem;
+    letter-spacing: 0.04em;
+    line-height: 1;
+    border-top: 3px solid #000;
+  }
+
+  .ack-ticker-track {
+    flex: 1;
+    overflow: hidden;
+    display: flex;
+    align-items: center;
+  }
+
+  .ack-ticker-scroll {
+    display: flex;
+    width: max-content;
+    transition: transform 900ms ease-in-out;
+  }
+
+  .ack-ticker-set {
+    display: inline-flex;
+    align-items: center;
+    flex-shrink: 0;
+  }
+
+  .ack-ticker-entry {
+    display: inline-flex;
+    align-items: center;
+    flex: 0 0 auto;
+    white-space: nowrap;
+  }
+
+  .ack-ticker-name {
+    padding: 8px 0;
+    color: #000;
+    text-decoration: none;
+  }
+
+  .ack-ticker-name:hover {
+    text-decoration: underline;
+  }
+
+  .ack-ticker-divider {
+    margin: 0 1.2em;
+    font-size: 0.45em;
+    vertical-align: middle;
+    opacity: 0.5;
+  }
+
+  .ack-ticker-label {
+    flex: 0 0 auto;
+    padding: 8px 1em;
+    border-left: 2px solid #000;
+    font-weight: 700;
+    text-transform: uppercase;
+    white-space: nowrap;
+    text-decoration: none;
+    color: #000;
+    background: #f5f5f0;
+    transition: background 0.15s;
+  }
+
+  .ack-ticker-label:hover {
+    background: #e8e8e3;
+  }
+
+  .ack-ticker-credit {
+    flex: 0 0 auto;
+    padding: 8px 1em;
+    border-right: 2px solid #000;
+    font-weight: 700;
+    text-transform: uppercase;
+    white-space: nowrap;
+    color: #000;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .ack-ticker-scroll {
+      transition: none;
+    }
+  }
+</style>

--- a/src/components/NewsTicker.astro
+++ b/src/components/NewsTicker.astro
@@ -1,0 +1,383 @@
+---
+import { getPosts } from "../lib/content";
+import {
+  firstMetadataValue,
+  getIndigestMessages,
+  getSlackColumns,
+} from "../lib/indigest";
+
+type Headline = {
+  title: string;
+  href: string;
+  date: number;
+};
+
+function timestampToNumber(timestamp: string | Date): number {
+  const parsed = new Date(timestamp).getTime();
+  if (!Number.isNaN(parsed)) return parsed;
+
+  const slackTimestamp = Number(timestamp);
+  return Number.isFinite(slackTimestamp) ? slackTimestamp * 1000 : 0;
+}
+
+const regularHeadlines: Headline[] = (await getPosts()).map((post) => ({
+  title: post.title,
+  href: post.url,
+  date: post.date.getTime(),
+}));
+
+const slackHeadlines = (
+  await Promise.all(
+    getSlackColumns().map(async (column) => {
+      try {
+        const messages = await getIndigestMessages(
+          column.channelId ?? column.column,
+          20,
+        );
+
+        return messages.map((message): Headline => ({
+          title: `${column.noun ?? column.title}: ${firstMetadataValue(message.metadata) ?? column.title}`,
+          href: `/slack/${encodeURIComponent(column.column)}/${encodeURIComponent(message.slackTs)}/`,
+          date: timestampToNumber(message.timestamp || message.slackTs),
+        }));
+      } catch {
+        return [];
+      }
+    }),
+  )
+).flat();
+
+const headlines = [...regularHeadlines, ...slackHeadlines]
+  .sort((a, b) => b.date - a.date)
+  .slice(0, 20);
+---
+
+<div class="news-ticker" aria-label="News ticker">
+  <span class="news-ticker-label">newswire</span>
+  <div class="news-ticker-track">
+    <div class="news-ticker-scroll" data-ticker>
+      <span class="news-ticker-set" data-ticker-set>
+        {headlines.map((headline) => (
+          <>
+            <span class="news-ticker-entry">
+              <a class="news-ticker-item" href={headline.href}>
+                {headline.title}
+              </a>
+              <span class="news-ticker-divider" aria-hidden="true">◆</span>
+            </span>
+          </>
+        ))}
+      </span>
+    </div>
+  </div>
+  <button class="news-ticker-pause" aria-label="Pause ticker" type="button">❚❚</button>
+</div>
+
+<script>
+  const TICKER_CACHE_KEY = "news-ticker:headlines:v2";
+
+  function cacheTicker() {
+    const set = document.querySelector("#news-ticker .news-ticker-set");
+    if (!(set instanceof HTMLElement)) return;
+    if (set.closest(".news-ticker--loading")) return;
+
+    try {
+      localStorage.setItem(
+        TICKER_CACHE_KEY,
+        JSON.stringify({ markup: set.innerHTML, cachedAt: Date.now() }),
+      );
+    } catch (_error) {
+      // Ignore unavailable or full browser storage.
+    }
+  }
+
+  function initializeTickers() {
+    document
+      .querySelectorAll("[data-ticker]:not([data-ticker-initialized])")
+      .forEach((scroll) => {
+        if (!(scroll instanceof HTMLElement)) return;
+        scroll.setAttribute("data-ticker-initialized", "true");
+        const set = scroll.querySelector("[data-ticker-set]");
+        if (!(set instanceof HTMLElement)) return;
+        const parent = scroll.parentElement;
+        if (!parent) return;
+
+        const items = Array.from(set.querySelectorAll(".news-ticker-entry"));
+        if (items.length === 0) return;
+
+        const dupe = set.cloneNode(true);
+        if (!(dupe instanceof HTMLElement)) return;
+        dupe.setAttribute("aria-hidden", "true");
+        scroll.appendChild(dupe);
+
+        let index = 0;
+        const step = () => {
+          index++;
+          const next = items[index];
+          if (next instanceof HTMLElement) {
+            scroll.style.transform = `translateX(-${next.offsetLeft}px)`;
+            return;
+          }
+
+          scroll.addEventListener(
+            "transitionend",
+            () => {
+              scroll.style.transition = "none";
+              scroll.style.transform = "translateX(0)";
+              index = 0;
+              requestAnimationFrame(() => {
+                scroll.style.transition = "";
+              });
+            },
+            { once: true },
+          );
+          scroll.style.transform = `translateX(-${set.offsetWidth}px)`;
+        };
+
+        window.setInterval(step, 5000);
+      });
+  }
+
+  function initializeSkeletonTickers() {
+    document
+      .querySelectorAll(
+        ".news-ticker-skeleton-scroll:not([data-ticker-initialized])",
+      )
+      .forEach((scroll) => {
+        const set = scroll.querySelector(".news-ticker-skeleton-set");
+        if (!(scroll instanceof HTMLElement) || !(set instanceof HTMLElement)) {
+          return;
+        }
+
+        scroll.setAttribute("data-ticker-initialized", "true");
+        const items = Array.from(
+          set.querySelectorAll(".news-ticker-skeleton-entry"),
+        );
+        if (items.length === 0) return;
+        const duplicate = set.cloneNode(true);
+        if (!(duplicate instanceof HTMLElement)) return;
+        duplicate.setAttribute("aria-hidden", "true");
+        scroll.appendChild(duplicate);
+
+        let index = 0;
+        window.setInterval(() => {
+          index++;
+          const next = items[index];
+          if (next instanceof HTMLElement) {
+            scroll.style.transform = `translateX(-${next.offsetLeft}px)`;
+            return;
+          }
+          scroll.addEventListener(
+            "transitionend",
+            () => {
+              scroll.style.transition = "none";
+              scroll.style.transform = "translateX(0)";
+              index = 0;
+              requestAnimationFrame(() => {
+                scroll.style.transition = "";
+              });
+            },
+            { once: true },
+          );
+          scroll.style.transform = `translateX(-${set.offsetWidth}px)`;
+        }, 5000);
+      });
+  }
+
+  function initializePauseButtons() {
+    document.querySelectorAll(".news-ticker-pause:not([data-pause-initialized])").forEach((btn) => {
+      btn.setAttribute("data-pause-initialized", "true");
+      btn.addEventListener("click", () => {
+        const ticker = btn.closest(".news-ticker");
+        if (!ticker) return;
+        const scroll = ticker.querySelector(".news-ticker-scroll");
+        if (!(scroll instanceof HTMLElement)) return;
+
+        const animations = scroll.getAnimations();
+        const isPaused = animations.some((a) => a.playState === "paused");
+
+        if (isPaused) {
+          animations.forEach((a) => a.play());
+          btn.textContent = "❚❚";
+          btn.setAttribute("aria-label", "Pause ticker");
+        } else {
+          animations.forEach((a) => a.pause());
+          btn.textContent = "▶";
+          btn.setAttribute("aria-label", "Resume ticker");
+        }
+      });
+    });
+  }
+
+  function initializeAllTickers() {
+    initializeTickers();
+    initializeSkeletonTickers();
+    initializePauseButtons();
+    cacheTicker();
+  }
+
+  function saveTickerPositions() {
+    document
+      .querySelectorAll(
+        ".news-ticker-scroll, .news-ticker-skeleton-scroll, .news-ticker-stale-scroll",
+      )
+      .forEach((scroll) => {
+        if (!(scroll instanceof HTMLElement)) return;
+
+        const currentTime = scroll.getAnimations()[0]?.currentTime;
+        if (typeof currentTime === "number") {
+          scroll.setAttribute("data-ticker-current-time", String(currentTime));
+          scroll.setAttribute("data-ticker-saved-at", String(performance.now()));
+        }
+      });
+  }
+
+  function restoreTickerPositions() {
+    document
+      .querySelectorAll(
+        ".news-ticker-scroll[data-ticker-current-time], .news-ticker-skeleton-scroll[data-ticker-current-time], .news-ticker-stale-scroll[data-ticker-current-time]",
+      )
+      .forEach((scroll) => {
+        if (!(scroll instanceof HTMLElement)) return;
+
+        const currentTime = Number(scroll.getAttribute("data-ticker-current-time"));
+        const savedAt = Number(scroll.getAttribute("data-ticker-saved-at"));
+        const duration = parseFloat(getComputedStyle(scroll).animationDuration) * 1000;
+        const navigationTime = Number.isFinite(savedAt)
+          ? performance.now() - savedAt
+          : 0;
+
+        if (!Number.isFinite(currentTime) || duration <= 0) return;
+
+        const animation = scroll.getAnimations()[0];
+        if (!animation) return;
+
+        scroll.style.animationDelay = "0s";
+        animation.currentTime = (currentTime + navigationTime) % duration;
+        animation.play();
+      });
+  }
+
+  function initializeAllTickersAndRestorePosition() {
+    initializeAllTickers();
+    restoreTickerPositions();
+  }
+
+  initializeAllTickers();
+  document.addEventListener("astro:before-swap", saveTickerPositions);
+  document.addEventListener("astro:after-swap", initializeAllTickersAndRestorePosition);
+  document.addEventListener("astro:page-load", initializeAllTickersAndRestorePosition);
+  new MutationObserver(initializeAllTickers).observe(document.body, {
+    childList: true,
+    subtree: true,
+  });
+</script>
+
+<style>
+  .news-ticker {
+    background: #f5f5f0;
+    color: #000;
+    display: flex;
+    align-items: stretch;
+    overflow: hidden;
+    font-family: Georgia, "Times New Roman", serif;
+    font-size: 0.8rem;
+    letter-spacing: 0.04em;
+    line-height: 1;
+    border-top: 3px solid #000;
+    border-bottom: 3px double #000;
+  }
+
+  .news-ticker--loading {
+    min-height: 31px;
+    align-items: center;
+    padding: 0 1em;
+  }
+
+  .news-ticker-skeleton {
+    display: block;
+    width: min(28rem, 55%);
+    height: 0.8em;
+    background: linear-gradient(90deg, #fff 25%, #f0f0eb 50%, #fff 75%);
+    background-size: 200% 100%;
+    animation: news-ticker-loading 1.5s infinite;
+  }
+
+  @keyframes news-ticker-loading {
+    from {
+      background-position: 200% 0;
+    }
+    to {
+      background-position: -200% 0;
+    }
+  }
+
+  .news-ticker-track {
+    flex: 1;
+    overflow: hidden;
+    display: flex;
+    align-items: center;
+  }
+
+  .news-ticker-label {
+    flex: 0 0 auto;
+    padding: 8px 1em;
+    border-right: 2px solid #000;
+    font-weight: 700;
+    text-transform: uppercase;
+    white-space: nowrap;
+  }
+
+  .news-ticker-scroll {
+    display: flex;
+    width: max-content;
+    transition: transform 900ms ease-in-out;
+  }
+
+  .news-ticker-set {
+    display: inline-flex;
+    align-items: center;
+    flex-shrink: 0;
+  }
+
+  .news-ticker-entry {
+    display: inline-flex;
+    align-items: center;
+    flex: 0 0 auto;
+    white-space: nowrap;
+  }
+
+  .news-ticker-item {
+    padding: 8px 0;
+  }
+
+  .news-ticker-divider {
+    margin: 0 1.2em;
+    font-size: 0.45em;
+    vertical-align: middle;
+    opacity: 0.5;
+  }
+
+  .news-ticker-pause {
+    flex: 0 0 auto;
+    padding: 8px 12px;
+    border: none;
+    border-left: 2px solid #000;
+    background: #f5f5f0;
+    font-size: 0.7rem;
+    cursor: pointer;
+    font-family: inherit;
+    color: #000;
+    transition: background 0.15s;
+  }
+
+  .news-ticker-pause:hover {
+    background: #e8e8e3;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .news-ticker-scroll {
+      transition: none;
+    }
+  }
+</style>

--- a/src/components/SiteFooter.astro
+++ b/src/components/SiteFooter.astro
@@ -19,7 +19,7 @@ try {
           <img src="https://assets.hackclub.com/flag-standalone.svg" alt="Hack Club" class="footer-hc-inline" />
           Hack Club Slack
         </span>
-        <span class="footer-commit">Built from commit <a href="https://github.com/hackclub/slacker-news/commit/{commitHash}"><code>#{commitHash}</code></a></span>
+        <span class="footer-commit">Built from commit <a href={`https://github.com/hackclub/slacker-news/commit/${commitHash}`}><code>#{commitHash}</code></a></span>
       </div>
         <div class="footer-nav">
           <div class="footer-col">

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -1,6 +1,9 @@
 ---
 import AbacusCounter from "../components/AbacusCounter.astro";
+import NewsTicker from "../components/NewsTicker.astro";
+import AcknowledgementsTicker from "../components/AcknowledgementsTicker.astro";
 import SiteFooter from "../components/SiteFooter.astro";
+import { ClientRouter } from "astro:transitions";
 
 interface Props {
   title?: string;
@@ -35,6 +38,10 @@ const pageTitle = title && title !== siteTitle ? `${title} | ${siteTitle}` : sit
 const pageDescription = description ?? siteDescription;
 const authReturnTo = `${Astro.url.pathname}${Astro.url.search}`;
 const isAuthenticated = Boolean(Astro.locals.user);
+const tickerSkeletonWidths = [
+  8, 12, 10, 15, 9, 13, 11, 14, 8, 15,
+  10, 12, 14, 9, 13, 15, 8, 11, 14, 10,
+];
 
 function toAbsoluteURL(input: string): string {
   return new URL(input, Astro.site ?? Astro.url).toString();
@@ -46,7 +53,7 @@ const socialImageAlt = openGraphImageAlt ?? `${siteTitle} social preview`;
 ---
 
 <!doctype html>
-<html lang="en" class="no-js">
+<html lang="en" class="no-js" data-authenticated={Astro.locals.user ? "1" : "0"} transition:animate="none">
   <head>
     <meta charset="utf-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
@@ -70,6 +77,9 @@ const socialImageAlt = openGraphImageAlt ?? `${siteTitle} social preview`;
     <meta property="og:image" content={socialImageURL} />
     <meta property="og:image:alt" content={socialImageAlt} />
 
+    <ClientRouter />
+
+
 
     {openGraphType === "article" && articlePublishedTime && (
       <meta property="article:published_time" content={articlePublishedTime} />
@@ -83,7 +93,6 @@ const socialImageAlt = openGraphImageAlt ?? `${siteTitle} social preview`;
     <!-- Privacy-friendly analytics by Plausible -->
     <script is:inline async src="https://plausible.io/js/pa-uvFjoLdnb2dzua4uEgT4v.js"></script>
     <script is:inline>
-      // oxlint-disable-next-line eslint/no-unused-expressions
       window.plausible=window.plausible||function(){(plausible.q=plausible.q||[]).push(arguments)},plausible.init=plausible.init||function(i){plausible.o=i||{}};
       plausible.init()
     </script>
@@ -186,6 +195,110 @@ const socialImageAlt = openGraphImageAlt ?? `${siteTitle} social preview`;
           </div>
         </nav>
       </div>
+      <div id="news-ticker" transition:persist="news-ticker">
+        <div id="news-ticker-stale" hidden aria-hidden="true"></div>
+        <div id="news-ticker-live">
+        <NewsTicker server:defer>
+          <div slot="fallback" class="news-ticker news-ticker--loading" aria-label="News ticker">
+            <span class="news-ticker-label">newswire</span>
+            <div class="news-ticker-skeleton-track" aria-hidden="true">
+              <div class="news-ticker-skeleton-scroll">
+                <div class="news-ticker-skeleton-set">
+                  {Array.from({ length: 20 }).map((_, index) => (
+                    <span class="news-ticker-skeleton-entry">
+                        <span
+                          class="news-ticker-skeleton-text"
+                          style={`--skeleton-width: ${tickerSkeletonWidths[index]}em`}
+                        ></span>
+                        <span class="news-ticker-skeleton-dot">◆</span>
+                    </span>
+                  ))}
+                </div>
+              </div>
+            </div>
+          </div>
+        </NewsTicker>
+        </div>
+      </div>
+      <script is:inline>
+        (function () {
+          var stale = document.getElementById("news-ticker-stale");
+          var live = document.getElementById("news-ticker-live");
+          if (!(stale instanceof HTMLElement) || !(live instanceof HTMLElement)) return;
+
+          try {
+            var cached = JSON.parse(localStorage.getItem("news-ticker:headlines:v2") || "null");
+            if (!cached || typeof cached.markup !== "string") return;
+
+            window.__newsTickerStartedAt = performance.now();
+            window.__newsTickerCachedMarkup = cached.markup;
+            stale.hidden = false;
+            live.style.display = "none";
+            var staleTickerTimer = 0;
+
+            var initializeStaleTicker = function () {
+              var scroll = stale.querySelector(".news-ticker-scroll");
+              var set = stale.querySelector(".news-ticker-set");
+              if (!(scroll instanceof HTMLElement) || !(set instanceof HTMLElement)) return;
+              if (scroll.hasAttribute("data-ticker-initialized")) return;
+              scroll.setAttribute("data-ticker-initialized", "true");
+              var items = Array.from(set.querySelectorAll(".news-ticker-entry"));
+              if (items.length === 0) return;
+              var duplicate = set.cloneNode(true);
+              if (!(duplicate instanceof HTMLElement)) return;
+              duplicate.setAttribute("aria-hidden", "true");
+              scroll.appendChild(duplicate);
+              var index = 0;
+              staleTickerTimer = window.setInterval(function () {
+                index++;
+                var next = items[index];
+                if (next instanceof HTMLElement) {
+                  scroll.style.transform = "translateX(-" + next.offsetLeft + "px)";
+                  return;
+                }
+                scroll.addEventListener("transitionend", function () {
+                  scroll.style.transition = "none";
+                  scroll.style.transform = "translateX(0)";
+                  index = 0;
+                  requestAnimationFrame(function () { scroll.style.transition = ""; });
+                }, { once: true });
+                scroll.style.transform = "translateX(-" + set.offsetWidth + "px)";
+              }, 5000);
+            };
+
+            var renderStaleTicker = function (markup) {
+              if (staleTickerTimer) window.clearInterval(staleTickerTimer);
+              stale.innerHTML =
+                '<span class="news-ticker-label">newswire</span>' +
+                '<div class="news-ticker-stale-track"><div class="news-ticker-scroll" data-ticker>' +
+                '<span class="news-ticker-set" data-ticker-set>' + markup + "</span></div></div>";
+              initializeStaleTicker();
+            };
+
+            renderStaleTicker(cached.markup);
+
+            var showFreshTicker = function () {
+              var freshSet = live.querySelector(".news-ticker:not(.news-ticker--loading) .news-ticker-set");
+              if (!(freshSet instanceof HTMLElement)) return;
+
+              if (freshSet.innerHTML === window.__newsTickerCachedMarkup) {
+                live.style.display = "none";
+                stale.hidden = false;
+              } else {
+                window.__newsTickerCachedMarkup = freshSet.innerHTML;
+                renderStaleTicker(freshSet.innerHTML);
+                live.style.display = "none";
+                stale.hidden = false;
+              }
+            };
+
+            new MutationObserver(showFreshTicker).observe(live, { childList: true, subtree: true });
+            showFreshTicker();
+          } catch (_error) {
+            // Ignore unavailable or malformed browser cache.
+          }
+        })();
+      </script>
     </header>
 
     <main class="page-content" aria-label="Content">
@@ -245,6 +358,7 @@ const socialImageAlt = openGraphImageAlt ?? `${siteTitle} social preview`;
       })();
     </script>
     <AbacusCounter pathname={Astro.url.pathname} />
+    <AcknowledgementsTicker />
     <SiteFooter />
   </body>
 </html>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,15 +1,11 @@
 ---
 import BaseLayout from "../layouts/BaseLayout.astro";
 import AuthorList from "../components/AuthorList.astro";
-import SlackMention from "../components/SlackMention.astro";
 import {
-  getAcknowledgements,
   getChangelogEntries,
   getPosts,
   getSiteConfig,
-  truncateWords,
-  type LongChangelogEntry,
-  type ChangelogEntry,
+  truncateWords
 } from "../lib/content";
 import HomepageSlackColumns from "../components/HomepageSlackColumns.astro";
 
@@ -23,19 +19,12 @@ import { getSlackColumns } from "../lib/indigest";
 
 const site = await getSiteConfig();
 const posts = await getPosts();
-const allChangelogs = await getChangelogEntries();
-const longChangelogs = allChangelogs.filter((e) => e.kind === "long");
 
 const allNews = posts.filter((post) => post.category === "news");
-
-const allCandidates = [
-  ...allNews.map((p) => ({ slug: p.slug, url: p.url, title: p.title, excerpt: p.excerpt, paragraphs: p.paragraphs, date: p.date, leadingImage: p.leadingImage })),
-  ...longChangelogs.map((c) => ({ slug: c.slug, url: c.url, title: c.title, excerpt: c.excerpt, paragraphs: c.paragraphs, date: new Date(`${c.date}T00:00:00Z`), leadingImage: c.leadingImage })),
-].sort((a, b) => b.date.getTime() - a.date.getTime());
-
-const headline = site.headlineOverride
-  ? allCandidates.find((c) => c.slug === site.headlineOverride) ?? allCandidates[0]
-  : allCandidates[0];
+const overrideHeadline = site.headlineOverride
+  ? posts.find((post) => post.slug === site.headlineOverride)
+  : undefined;
+const headline = overrideHeadline ?? allNews[0];
 const headlineExcerptWordLimit = headline?.leadingImage ? 75 : 110;
 const headlineExcerpts = (() => {
   const paras = headline?.paragraphs ?? [];
@@ -44,8 +33,6 @@ const headlineExcerpts = (() => {
     if (!s) return false;
     if (/^#{1,6}\s+/.test(s)) return false;
     if (/^[=-]{3,}\s*$/.test(s)) return false;
-    if (/^>\s/.test(s)) return false;
-    if (/^\u201C/.test(s)) return false;
     const words = s.split(/\s+/).length;
     if (words < 6) return false;
     if (s.length < 40) return false;
@@ -64,34 +51,13 @@ const [opinionItems, newsItems, essayItems] = await Promise.all([
 
 const displayOpinion = opinionItems.slice(0, 3);
 
-function changelogToPostLike(changelog: LongChangelogEntry) {
-  return {
-    kind: "post" as const,
-    post: {
-      slug: changelog.slug,
-      url: changelog.url,
-      title: changelog.title,
-      excerpt: changelog.excerpt,
-      readingTime: changelog.readingTime,
-      date: new Date(`${changelog.date}T00:00:00Z`),
-    },
-    date: new Date(`${changelog.date}T00:00:00Z`),
-  };
-}
-
-const longChangelogItems = longChangelogs.map((c) => changelogToPostLike(c as LongChangelogEntry));
-
-const combinedNewsAndChangelogs = [...newsItems, ...longChangelogItems]
+const displayNews = newsItems
   .filter((item) => item.kind !== "post" || item.post.slug !== headline?.slug)
-  .sort((a, b) => b.date.getTime() - a.date.getTime())
   .slice(0, 8);
-
-const displayNews = combinedNewsAndChangelogs;
 
 const displayEssays = essayItems.slice(0, 4);
 
-const recentChangelog = allChangelogs.slice(0, 3);
-const acknowledgements = await getAcknowledgements();
+const recentChangelog = (await getChangelogEntries()).slice(0, 3);
 const homepageSlackColumns = getSlackColumns().filter((column) => column.homepage);
 
 function getSlackMessagesPerRow(column: { homepageMessagesPerRow?: number }): number {
@@ -101,6 +67,7 @@ function getSlackMessagesPerRow(column: { homepageMessagesPerRow?: number }): nu
 function getSlackHomepageLimit(column: { homepageLimit?: number; homepageFetchLimit?: number; limit?: number }): number {
   return Math.min(Math.max(Math.round(column.homepageLimit ?? column.homepageFetchLimit ?? column.limit ?? 5), 1), 100);
 }
+
 ---
 
 <BaseLayout siteTitle={site.title} siteDescription={site.description}>
@@ -173,8 +140,10 @@ function getSlackHomepageLimit(column: { homepageLimit?: number; homepageFetchLi
 
     <hr class="section-rule" />
 
-    <HomepageSlackColumns server:defer returnTo={Astro.url.pathname}>
-      <div slot="fallback" class="front-slack-columns">
+    <div id="homepage-slack-columns-stale" hidden aria-hidden="true"></div>
+    <div id="homepage-slack-columns-live">
+      <HomepageSlackColumns server:defer returnTo={Astro.url.pathname}>
+        <div slot="fallback" class="front-slack-columns">
         {homepageSlackColumns.map((column) => (
           <>
             <section class="slack-column-row slack-column-row--loading">
@@ -190,15 +159,66 @@ function getSlackHomepageLimit(column: { homepageLimit?: number; homepageFetchLi
                 ))}
               </div>
             </section>
-            <a class="news-archive-link" href={`/slack/${encodeURIComponent(column.channel)}/`}>All {column.title} &rarr;</a>
+            <a class="news-archive-link" href={`/slack/${encodeURIComponent(column.column)}/`}>All {column.title} &rarr;</a>
             <hr class="section-rule" />
           </>
         ))}
-      </div>
-    </HomepageSlackColumns>
+        </div>
+      </HomepageSlackColumns>
+    </div>
+    <script is:inline>
+      (function () {
+        var stale = document.getElementById("homepage-slack-columns-stale");
+        var live = document.getElementById("homepage-slack-columns-live");
+        if (!(stale instanceof HTMLElement) || !(live instanceof HTMLElement)) return;
+
+        var cacheKey = "homepage-slack-columns:v1:" + (document.documentElement.dataset.authenticated || "0");
+        var signature = function (root) {
+          return Array.from(root.querySelectorAll(".slack-column-card-title-link"))
+            .map(function (link) { return link.getAttribute("href") + "|" + link.textContent; })
+            .join("\n");
+        };
+
+        try {
+          var cached = JSON.parse(localStorage.getItem(cacheKey) || "null");
+          if (cached && typeof cached.markup === "string" && typeof cached.signature === "string") {
+            stale.innerHTML = cached.markup.indexOf("front-slack-columns") >= 0
+              ? cached.markup
+              : '<div class="front-slack-columns">' + cached.markup + "</div>";
+            stale.hidden = false;
+            live.style.display = "none";
+          }
+
+          var update = function () {
+            var fresh = live.querySelector(".slack-column-card-title-link, .slack-auth-prompt");
+            if (!fresh) return;
+            var freshSignature = signature(live);
+            if (cached && freshSignature === cached.signature) {
+              live.style.display = "none";
+              stale.hidden = false;
+              return;
+            }
+            var island = live.querySelector("astro-island");
+            var markup = island ? island.innerHTML : live.innerHTML;
+            stale.innerHTML = markup.indexOf("front-slack-columns") >= 0
+              ? markup
+              : '<div class="front-slack-columns">' + markup + "</div>";
+            stale.hidden = false;
+            live.style.display = "none";
+            localStorage.setItem(cacheKey, JSON.stringify({ markup: markup, signature: freshSignature }));
+            cached = { markup: markup, signature: freshSignature };
+          };
+
+          new MutationObserver(update).observe(live, { childList: true, subtree: true });
+          update();
+        } catch (_error) {
+          // Ignore unavailable or malformed browser cache.
+        }
+      })();
+    </script>
 
 
-    <div class="front-changelog">
+    <div class="front-changelog front-changelog--full">
       <div class="front-block changelog-block">
         <div class="section-label">CHANGELOG</div>
         <hr class="block-rule" />
@@ -219,22 +239,6 @@ function getSlackHomepageLimit(column: { homepageLimit?: number; homepageFetchLi
         ))}
         {recentChangelog.length > 0 && <hr class="changelog-divider" />}
         <a href="/changelogs/" class="archive-link">All changelogs &rarr;</a>
-      </div>
-
-      <div class="front-block acknowledgements-block">
-        <div class="section-label">ACKNOWLEDGEMENTS</div>
-        <hr class="block-rule" />
-        <div class="acknowledgements-grid">
-          {acknowledgements.map((person) => {
-            const userName = person.name.trim().replace(/^@+/, "");
-            return (
-              <span class="acknowledgement-name">
-                {person.slackId ? <SlackMention name={userName} id={person.slackId} /> : person.name}
-              </span>
-            );
-          })}
-        </div>
-        <a href="/acknowledgements/" class="archive-link">All acknowledgements &rarr;</a>
       </div>
     </div>
   </div>

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -46,15 +46,16 @@ a {
 
 .site-header {
   border-top: 5px solid #000;
-  border-bottom: 3px double #000;
+  border-bottom: none;
   background-color: #fff;
   text-align: center;
-  padding: 12px 0;
+  padding: 0;
 
   .wrapper {
     display: flex;
     flex-direction: column;
     align-items: center;
+    padding: 12px 0;
   }
 }
 
@@ -98,6 +99,135 @@ a {
       display: none;
     }
   }
+}
+
+// ─── Deferred news ticker fallback ──────────────────────────────────────────
+
+.news-ticker--loading {
+  display: flex;
+  align-items: center;
+  min-height: 31px;
+  overflow: hidden;
+  padding: 0 1em;
+  border-top: 3px solid #000;
+  border-bottom: 3px double #000;
+  background: #f5f5f0;
+}
+
+#news-ticker-stale {
+  display: flex;
+  align-items: stretch;
+  overflow: hidden;
+  min-height: 31px;
+  background: #f5f5f0;
+  color: #000;
+  font-family: Georgia, "Times New Roman", serif;
+  font-size: 0.8rem;
+  letter-spacing: 0.04em;
+  line-height: 1;
+  border-top: 3px solid #000;
+  border-bottom: 3px double #000;
+}
+
+#news-ticker-stale[hidden] {
+  display: none !important;
+}
+
+.news-ticker-stale-track {
+  flex: 1;
+  overflow: hidden;
+}
+
+.news-ticker-stale-track .news-ticker-scroll {
+  display: flex;
+  width: max-content;
+  transition: transform 900ms ease-in-out;
+}
+
+.news-ticker-label {
+  flex: 0 0 auto;
+  padding: 8px 1em;
+  margin-right:8px;
+  border-right: 2px solid #000;
+  font-weight: 700;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.news-ticker-stale-track .news-ticker-set {
+  display: inline-flex;
+  align-items: center;
+  flex: 0 0 max-content;
+  white-space: nowrap;
+}
+
+.news-ticker-stale-track .news-ticker-entry {
+  display: inline-flex;
+  align-items: center;
+  flex: 0 0 auto;
+  white-space: nowrap;
+}
+
+.news-ticker-stale-track .news-ticker-item {
+  padding: 8px 0;
+}
+
+.news-ticker-stale-track .news-ticker-divider {
+  margin: 0 1.2em;
+  font-size: 0.45em;
+  vertical-align: middle;
+  opacity: 0.5;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .news-ticker-stale-track .news-ticker-scroll,
+  .news-ticker-skeleton-scroll {
+    transition: none;
+  }
+}
+
+.news-ticker-skeleton-set {
+  display: flex;
+  align-items: center;
+  flex: 0 0 max-content;
+  white-space: nowrap;
+}
+
+.news-ticker-skeleton-track {
+  width: 100%;
+  overflow: hidden;
+}
+
+.news-ticker-skeleton-scroll {
+  display: flex;
+  width: max-content;
+  transition: transform 900ms ease-in-out;
+}
+
+.news-ticker-skeleton-entry {
+  display: inline-flex;
+  align-items: center;
+  flex: 0 0 auto;
+}
+
+.news-ticker-skeleton-text {
+  display: inline-block;
+  flex: 0 0 var(--skeleton-width, 10em);
+  height: 0.8em;
+  background: linear-gradient(90deg, #fff 25%, #f0f0eb 50%, #fff 75%);
+  background-size: 200% 100%;
+  animation: news-ticker-loading 1.5s infinite;
+}
+
+.news-ticker-skeleton-dot {
+  margin: 0 1.2em;
+  color: #999;
+  font-size: 0.45em;
+}
+
+@keyframes news-ticker-loading {
+  from { background-position: 200% 0; }
+  to { background-position: -200% 0; }
 }
 
 // ─── Front page grid ─────────────────────────────────────────────────────────
@@ -313,6 +443,14 @@ a {
   display: grid;
   grid-template-columns: 1fr 1fr;
   gap: 20px;
+
+  &--full {
+    grid-template-columns: 1fr;
+
+    .changelog-block {
+      max-width: 100%;
+    }
+  }
 
   .changelog-block {
     &:hover {
@@ -819,39 +957,6 @@ a {
           currentColor 0 calc(100% - 14px),
           transparent calc(100% - 14px) 100%
         );
-      }
-    }
-
-    .footnotes {
-      margin-top: 2em;
-      padding-top: 1em;
-      border-top: 1px solid #ccc;
-      font-size: 0.88rem;
-      color: #444;
-
-      hr {
-        display: none;
-      }
-
-      ol {
-        margin: 0;
-        padding-left: 1.5em;
-      }
-
-      li {
-        margin-bottom: 0.6em;
-
-        &:last-child {
-          margin-bottom: 0;
-        }
-      }
-
-      a {
-        text-decoration: none;
-
-        &:hover {
-          text-decoration: underline;
-        }
       }
     }
   }


### PR DESCRIPTION
## Summary
Stacked on #149

- JS setInterval with translateX stepping
- "newswire" label on left
- Pause button (❚❚/▶) on right
- Full-width changelog card on homepage
- ClientRouter for view transitions
- Skeleton loading state for ticker
- Stale ticker cache for instant display